### PR TITLE
remember me機能の追加

### DIFF
--- a/rails_app/app/assets/stylesheets/users.scss
+++ b/rails_app/app/assets/stylesheets/users.scss
@@ -37,3 +37,22 @@ input {
     color: $state-danger-text;
   }
 }
+
+.checkbox {
+  margin-top: -10px;
+  margin-bottom: 10px;
+
+  .checkbox-box {
+    margin-left: -49% !important;
+  }
+
+  span {
+    margin-left: 20px;
+    font-weight: normal;
+  }
+}
+
+#session_remember_me {
+  width: auto;
+  margin-left: 0;
+}

--- a/rails_app/app/controllers/sessions_controller.rb
+++ b/rails_app/app/controllers/sessions_controller.rb
@@ -5,23 +5,23 @@ class SessionsController < ApplicationController
     # emailからユーザーを探す
     email = params[:session][:email].downcase
     password = params[:session][:password]
-    user = User.find_by(email: email)
+    @user = User.find_by(email: email)
 
     # ユーザーが見つからなかった or パスワードが間違ってたらエラーを返す
-    if !user || !user.authenticate(password)
+    if !@user || !@user.authenticate(password)
       flash.now[:danger] = 'Invalid email/password combination.'
       render 'new'
       return
     end
 
     # ログイン
-    log_in user
+    log_in @user
 
     # remeber meにチェックを入れていればログイントークンを記憶する
     # チェックなしならログイントークンを削除
-    params[:session][:remember_me] == '1' ? remember(user) : forget(user)
+    params[:session][:remember_me] == '1' ? remember(@user) : forget(@user)
 
-    redirect_to user_path(user)
+    redirect_to user_path(@user)
   end
 
   def destroy

--- a/rails_app/app/controllers/sessions_controller.rb
+++ b/rails_app/app/controllers/sessions_controller.rb
@@ -17,8 +17,9 @@ class SessionsController < ApplicationController
     # ログイン
     log_in user
 
-    # ログイン情報を記憶する
-    remember user
+    # remeber meにチェックを入れていればログイントークンを記憶する
+    # チェックなしならログイントークンを削除
+    params[:session][:remember_me] == '1' ? remember(user) : forget(user)
 
     redirect_to user_path(user)
   end

--- a/rails_app/app/controllers/sessions_controller.rb
+++ b/rails_app/app/controllers/sessions_controller.rb
@@ -24,7 +24,8 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    log_out
+    # ログイン済の場合のみログアウト
+    log_out if logged_in?
     redirect_to root_path
   end
 end

--- a/rails_app/app/controllers/sessions_controller.rb
+++ b/rails_app/app/controllers/sessions_controller.rb
@@ -16,6 +16,10 @@ class SessionsController < ApplicationController
 
     # ログイン
     log_in user
+
+    # ログイン情報を記憶する
+    remember user
+
     redirect_to user_path(user)
   end
 

--- a/rails_app/app/helpers/sessions_helper.rb
+++ b/rails_app/app/helpers/sessions_helper.rb
@@ -26,8 +26,11 @@ module SessionsHelper
       user = User.find_by(id: user_id)
 
       # remember_tokenが正しくない場合nilを返す
-      return nil if !user && !user.authenticated?(cookies[:remember_token])
+      if !user || !user.authenticated?(cookies[:remember_token])
+        return @current_user = nil
+      end
 
+      # ログイン(セッション情報を更新)
       log_in user
       return @current_user = user
     end
@@ -38,8 +41,21 @@ module SessionsHelper
     return !current_user.nil?
   end
 
+  def forget(user)
+    user.forget(current_user)
+    cookies.delete(:user_id)
+    cookies.delete(:remember_token)
+  end
+
+  #  現在のユーザーをログアウトする
   def log_out
+    # cookieを削除
+    forget(current_user)
+
+    # セッションを削除
     session.delete(:user_id)
+
+    # ユーザー変数を初期化
     @current_user = nil
   end
 end

--- a/rails_app/app/helpers/sessions_helper.rb
+++ b/rails_app/app/helpers/sessions_helper.rb
@@ -34,6 +34,9 @@ module SessionsHelper
       log_in user
       return @current_user = user
     end
+
+    # セッションにもcookieにも情報ない場合はnilを返す
+    return @current_user = nil
   end
 
   # ログイン済ならtrue
@@ -54,8 +57,5 @@ module SessionsHelper
 
     # セッションを削除
     session.delete(:user_id)
-
-    # ユーザー変数を初期化
-    @current_user = nil
   end
 end

--- a/rails_app/app/models/user.rb
+++ b/rails_app/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
     return BCrypt::Password.new(@remember_digest).is_password?(remember_token)
   end
 
-  # ユーザーのログイン情報を破棄する
+  # DBに保存していたユーザーのログイントークンを破棄する
   def forget(user)
     user.update_attribute(:remember_digest, nil)
   end

--- a/rails_app/app/models/user.rb
+++ b/rails_app/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   attr_accessor :remember_token
 
   # モデル保存前にメールアドレスを小文字に変換する
-  before_save { email.downcase! }
+  before_save { self.email.downcase! }
   validates :name, presence: true, length: { maximum: 50 }
   validates :email,
             presence: true,
@@ -31,9 +31,11 @@ class User < ApplicationRecord
   # 渡されたトークンがダイジェストと一致したらtrueを返す
   def authenticated?(remember_token)
     # DBのログイントークン(remember_digest)が空のときはfalseを返す
-    return false if remember_digest.nil?
+    return false if self.remember_digest.nil?
 
-    return BCrypt::Password.new(@remember_digest).is_password?(remember_token)
+    return(
+      BCrypt::Password.new(self.remember_digest).is_password?(remember_token)
+    )
   end
 
   # DBに保存していたユーザーのログイントークンを破棄する

--- a/rails_app/app/models/user.rb
+++ b/rails_app/app/models/user.rb
@@ -33,6 +33,11 @@ class User < ApplicationRecord
     return BCrypt::Password.new(@remember_digest).is_password?(remember_token)
   end
 
+  # ユーザーのログイン情報を破棄する
+  def forget(user)
+    user.update_attribute(:remember_digest, nil)
+  end
+
   # 渡された文字列のハッシュ値を返す
   def self.digest(string)
     # 暗号化コスト設定

--- a/rails_app/app/models/user.rb
+++ b/rails_app/app/models/user.rb
@@ -28,6 +28,11 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, User.digest(@remember_token))
   end
 
+  # 渡されたトークンがダイジェストと一致したらtrueを返す
+  def authenticated?(remember_token)
+    return BCrypt::Password.new(@remember_digest).is_password?(remember_token)
+  end
+
   # 渡された文字列のハッシュ値を返す
   def self.digest(string)
     # 暗号化コスト設定

--- a/rails_app/app/models/user.rb
+++ b/rails_app/app/models/user.rb
@@ -2,6 +2,8 @@
 VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
 
 class User < ApplicationRecord
+  attr_accessor :remember_token
+
   # モデル保存前にメールアドレスを小文字に変換する
   before_save { email.downcase! }
   validates :name, presence: true, length: { maximum: 50 }
@@ -19,6 +21,13 @@ class User < ApplicationRecord
   has_secure_password
   validates :password, presence: true, length: { minimum: 6 }
 
+  def remember
+    @remember_token = User.new_token
+
+    # バリデーションをスルーしてレコードを更新
+    update_attribute(:remember_digest, User.digest(@remember_token))
+  end
+
   # 渡された文字列のハッシュ値を返す
   def self.digest(string)
     # 暗号化コスト設定
@@ -30,5 +39,10 @@ class User < ApplicationRecord
       end
 
     return BCrypt::Password.create(string, cost: cost)
+  end
+
+  # ランダムなトークンを返す(22文字)
+  def self.new_token
+    return SecureRandom.urlsafe_base64
   end
 end

--- a/rails_app/app/models/user.rb
+++ b/rails_app/app/models/user.rb
@@ -30,6 +30,9 @@ class User < ApplicationRecord
 
   # 渡されたトークンがダイジェストと一致したらtrueを返す
   def authenticated?(remember_token)
+    # DBのログイントークン(remember_digest)が空のときはfalseを返す
+    return false if remember_digest.nil?
+
     return BCrypt::Password.new(@remember_digest).is_password?(remember_token)
   end
 

--- a/rails_app/app/views/sessions/new.html.erb
+++ b/rails_app/app/views/sessions/new.html.erb
@@ -10,6 +10,11 @@
     <%= f.label :password %><!--  -->
     <%= f.password_field :password, class: 'form-control' %><!--  -->
 
+    <%= f.label :remember_me, class: 'checkbox inline' do %><!--  -->
+    <%= f.check_box :remember_me, class: 'checkbox-box' %><!--  -->
+    <span>Remember me on this computer</span>
+    <% end %><!--  -->
+
     <%= f.submit "Log in", class: 'btn btn-primary' %><!--  -->
     <% end %><!--  -->
 

--- a/rails_app/db/migrate/20210812093809_add_remember_digest_to_users.rb
+++ b/rails_app/db/migrate/20210812093809_add_remember_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddRememberDigestToUsers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :remember_digest, :string
+  end
+end

--- a/rails_app/db/schema.rb
+++ b/rails_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20210810084413) do
+ActiveRecord::Schema.define(version: 20210812093809) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,7 @@ ActiveRecord::Schema.define(version: 20210810084413) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "password_digest"
+    t.string "remember_digest"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/rails_app/test/helpers/sessions_helper_test.rb
+++ b/rails_app/test/helpers/sessions_helper_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class SessionsHelperTest < ActionView::TestCase
+  def setup
+    @user = users(:michael)
+
+    # セッションを永続化
+    remember(@user)
+  end
+
+  test '正常系_セッションがnilのときに正しいユーザーを返す' do
+    assert_equal @user, current_user
+
+    # current_userを呼ぶとセッションにデータが保存されることを確認
+    assert is_logged_in_session_test?
+  end
+
+  test '異常系_rememberトークンが間違っている場合にユーザーがnilになる' do
+    # DBのremember_digestを更新
+    @user.update_attribute(:remember_digest, User.digest(User.new_token))
+
+    assert_nil current_user
+  end
+end

--- a/rails_app/test/integration/users_login_test.rb
+++ b/rails_app/test/integration/users_login_test.rb
@@ -105,6 +105,9 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
 
     # cookieにremember_tokenが保存されている
     assert_not_empty cookies['remember_token']
+
+    # 保存されているremember_tokenがcontrollerのuserインスタンスと同じか
+    assert_equal cookies['remember_token'], assigns(:user).remember_token
   end
 
   test '正常系_ログイン_remember_me_不使用' do

--- a/rails_app/test/integration/users_login_test.rb
+++ b/rails_app/test/integration/users_login_test.rb
@@ -59,7 +59,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
          }
 
     #  セッションにユーザーIDがあるか
-    assert is_logged_in_session?
+    assert is_logged_in_session_test?
 
     # リダイレクト
     assert_redirected_to user_path(@user)
@@ -80,7 +80,7 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     delete logout_path
 
     # セッションからユーザーIDが消えているか
-    assert_not is_logged_in_session?
+    assert_not is_logged_in_session_test?
 
     # リダイレクト
     assert_redirected_to root_path
@@ -98,5 +98,24 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
 
     # ユーザー詳細へのリンクがない
     assert_select 'a[href=?]', user_path(@user), count: 0
+  end
+
+  test '正常系_ログイン_remember_me' do
+    log_in_as_test(@user, remember_me: '1')
+
+    # cookieにremember_tokenが保存されている
+    assert_not_empty cookies['remember_token']
+  end
+
+  test '正常系_ログイン_remember_me_不使用' do
+    # クッキーを保存してログイン
+    log_in_as_test(@user, remember_me: '1')
+
+    # ログアウト(クッキーは残る)
+    delete logout_path
+
+    # クッキーを削除してログイン
+    log_in_as_test(@user, remember_me: '0')
+    assert_empty cookies['remember_token']
   end
 end

--- a/rails_app/test/integration/users_login_test.rb
+++ b/rails_app/test/integration/users_login_test.rb
@@ -86,6 +86,10 @@ class UsersLoginTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
     follow_redirect!
 
+    # 複数ウィンドウでログアウトクリックしたときにエラーにならないか
+    delete logout_path
+    follow_redirect!
+
     # ログインリンクがある
     assert_select 'a[href=?]', login_path
 

--- a/rails_app/test/integration/users_signup_test.rb
+++ b/rails_app/test/integration/users_signup_test.rb
@@ -42,6 +42,6 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_not flash[:success].empty?
 
     # セッションにユーザーIDがある
-    assert is_logged_in_session?
+    assert is_logged_in_session_test?
   end
 end

--- a/rails_app/test/models/user_test.rb
+++ b/rails_app/test/models/user_test.rb
@@ -88,4 +88,8 @@ class UserTest < ActiveSupport::TestCase
     @user.password = @user.password_confirmation = 'a' * 5
     assert_not @user.valid?
   end
+
+  test '異常系_remember_digestが空文字で認証状態を確認してもエラーにならない' do
+    assert_not @user.authenticated?('')
+  end
 end

--- a/rails_app/test/test_helper.rb
+++ b/rails_app/test/test_helper.rb
@@ -10,9 +10,28 @@ class ActiveSupport::TestCase
   include ApplicationHelper
 
   # セッションにユーザーIDがあればtrue
-  def is_logged_in_session?
+  def is_logged_in_session_test?
     return !session[:user_id].nil?
   end
 
+  # テストユーザーとしてログインする(単体テスト用)
+  def log_in_as_test(user)
+    session[:user_id] = user.id
+  end
+
   # Add more helper methods to be used by all tests here...
+end
+
+class ActionDispatch::IntegrationTest
+  # テストユーザーとしてログインする(統合テスト用)
+  def log_in_as_test(user, password: 'password', remember_me: '1')
+    post login_path,
+         params: {
+           session: {
+             email: user.email,
+             password: password,
+             remember_me: remember_me
+           }
+         }
+  end
 end


### PR DESCRIPTION
実装内容:
- rememberトークンをDB、クッキーに保存するようにした
- DB、クッキーのrememberトークンを突き合わせて認証するようにした
- ログイン時にrememer meを使うかチェックボックスを用意
- 関連するテストを追加